### PR TITLE
fix: fix invalid submodule references in examples

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -40,7 +40,7 @@ module "kv" {
 }
 
 module "runbooks" {
-  source  = "cloudnationhq/aa/azure/modules/runbooks"
+  source  = "cloudnationhq/aa/azure//modules/runbooks"
   version = "~> 0.1"
 
   naming = local.naming

--- a/examples/runbooks/main.tf
+++ b/examples/runbooks/main.tf
@@ -18,7 +18,7 @@ module "rg" {
 }
 
 module "runbooks" {
-  source  = "cloudnationhq/aa/azure/modules/runbooks"
+  source  = "cloudnationhq/aa/azure//modules/runbooks"
   version = "~> 0.1"
 
   naming = local.naming


### PR DESCRIPTION
## Description

The module source attribute in the submodule runbook referencing to the registry is fixed in this PR

## PR Checklist

- [x] I have checked if my changes close any open issues. If so please include appropriate [closing keywords](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword) below.
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules

- [x] Bug Fix
- [ ] New Feature (ie adding a service, resource, or data source)
- [ ] Enhancement
- [ ] Breaking change (not backwards compatible with previous releases)
